### PR TITLE
resolve interactive inference stalling

### DIFF
--- a/src/tile2net/namespace.py
+++ b/src/tile2net/namespace.py
@@ -452,6 +452,7 @@ class Namespace(
     immutable: False
 
     # torch_version = torch_version_float()
+    interactive: bool = False
 
     @cached_property
     def torch_version(self):
@@ -489,7 +490,8 @@ class Namespace(
 
         project = None
         if (
-            not sys.stdin.isatty()
+            not self.interactive
+            and not sys.stdin.isatty()
             and (text := sys.stdin.read()) != ''
         ):
             # case: piped

--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -374,11 +374,11 @@ class Raster(Grid):
         if not outfiles:
             logger.info(f'All tiles already stitched.')
             return
-        # print(self.project.tiles.static.files)
         infiles: np.ndarray = pipe(
             self.tiles,
             self.project.tiles.static.files,
-            toolz.curry(np.fromiter, dtype=object)
+            list,
+            np.array
         )
         indices = np.arange(self.tiles.size).reshape((self.width, self.height))
         indices = (
@@ -825,19 +825,25 @@ class Raster(Grid):
         )
         args = [
             'python',
-            Path(__file__).parent.parent.absolute().__str__(),
+            '-m',
+            'tile2net',
             'inference',
             '--city_info',
             str(info),
+            '--interactive',
         ]
+        logger.info(f'Running {args}')
         if eval_folder:
             args.extend(['--eval_folder', str(eval_folder)])
         try:
+            # todo: capture_outputs=False if want instant printout
             subprocess.run(
                 args,
-                check=True, capture_output=True, text=True,
+                check=True,
+                capture_output=True,
+                text=True,
             )
-        except subprocess.CalledProcessError as e:
+        except  subprocess.CalledProcessError  as e:
             logger.error(
                 f"Command {e.cmd} returned non-zero exit status {e.returncode}.\n"
                 f"Stdout: {e.stdout}\n"

--- a/src/tile2net/tileseg/config.py
+++ b/src/tile2net/tileseg/config.py
@@ -263,6 +263,7 @@ __C.BOUNDARY_PATH = None
 __C.NGPU = torch.cuda.device_count()
 __C.WORLD_SIZE = 1
 
+__C.INTERACTIVE = False
 
 def torch_version_float():
     version_str = torch.__version__

--- a/src/tile2net/tileseg/inference/commandline.py
+++ b/src/tile2net/tileseg/inference/commandline.py
@@ -314,4 +314,9 @@ commandline = compose_left(
         # default=None,
         help='path to the boundary file shapefile'
     ),
+    arg(
+        '--interactive',
+        action='store_true',
+        help='tile2net is being run in interactive python'
+    )
 )


### PR DESCRIPTION
When run in interactive mode, inference would stall because `sys.stdin.isatty()` returns True however no input is actually ever piped to the subprocess. The solution is to add another commandline argument, `--interactive` that serves as a flag that the process is being run interactively and shouldn't (indefinitely) try reading from stdin:
```
        if (
            not self.interactive
            and not sys.stdin.isatty()
            and (text := sys.stdin.read()) != ''
        ):
```
When `Raster.inference` runs the subprocess, the new arguments are:
```
        args = [
            'python',
            '-m',
            'tile2net',
            'inference',
            '--city_info',
            str(info),
            '--interactive',
        ]
```