### PR TITLE
Local/tile2net/dhodcz2

### DIFF
--- a/examples/inference.ipynb
+++ b/examples/inference.ipynb
@@ -31,7 +31,9 @@
     "\n",
     "<strong>padding</strong>: Whether or not to pad the tiles. The default is True, which means that the tiles will be padded to the size of the base_tilesize. If you want to use the original size of the tiles, you would pass False.\n",
     "\n",
-    "<strong>extension</strong>: The extension of the tiles. The default is 'png', which is the standard extension for Web Map Tile Services.\n"
+    "<strong>extension</strong>: The extension of the tiles. The default is 'png', which is the standard extension for Web Map Tile Services.\n",
+    "\n",
+    "<strong>dump_percent</strong>: The percent of segmentation images to dump to the subdirectory 'segmentation/seg_results': 100 means all, 0 means none. The default is 0.\n"
    ],
    "metadata": {
     "collapsed": false

--- a/src/tile2net/namespace.py
+++ b/src/tile2net/namespace.py
@@ -451,7 +451,7 @@ class Namespace(
 
     immutable: False
 
-    result_percent: int = None
+    dump_percent: int = None
 
     # torch_version = torch_version_float()
     interactive: bool = False

--- a/src/tile2net/namespace.py
+++ b/src/tile2net/namespace.py
@@ -451,6 +451,8 @@ class Namespace(
 
     immutable: False
 
+    result_percent: int = None
+
     # torch_version = torch_version_float()
     interactive: bool = False
 
@@ -535,7 +537,9 @@ class Namespace(
 
         if not self.eval_folder:
             raise ValueError('eval_folder must be set')
-        if not self.result_dir:
+        # if not self.result_dir:
+        #     raise ValueError('result_dir must be set')
+        if self.result_percent and self.result_dir:
             raise ValueError('result_dir must be set')
         if not self.model.snapshot:
             self.model.snapshot = (

--- a/src/tile2net/namespace.py
+++ b/src/tile2net/namespace.py
@@ -537,9 +537,7 @@ class Namespace(
 
         if not self.eval_folder:
             raise ValueError('eval_folder must be set')
-        # if not self.result_dir:
-        #     raise ValueError('result_dir must be set')
-        if self.result_percent and self.result_dir:
+        if not self.result_dir:
             raise ValueError('result_dir must be set')
         if not self.model.snapshot:
             self.model.snapshot = (

--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -165,6 +165,7 @@ class Raster(Grid):
         padding=True,
         # extension: str = 'png',
         source: Source | Type[Source] = None,
+        dump_percent: int = 0,
     ):
         """
 
@@ -204,6 +205,8 @@ class Raster(Grid):
             extension of the input images (default: 'png')
         source: Source | Type[Source] | str
             tile source (default: None)
+        dump_percent: int
+            percentage of the tiles to dump (default: None)
         """
         if name is None:
             name = util.name_from_location(location)
@@ -250,6 +253,8 @@ class Raster(Grid):
             raise ValueError('Zoom level must be specified')
         if tile_step & (tile_step - 1):
             raise ValueError('Tile step must be a power of 2')
+        if not 0 <= dump_percent <= 100:
+            raise ValueError('Dump percent must be between 0 and 100')
 
         self.zoom = zoom
         self.source = source
@@ -264,6 +269,7 @@ class Raster(Grid):
         self.boundary_path = ''
         self.input_dir: InputDir = input_dir
         self.source = source
+        self.dump_percent = dump_percent
 
         if boundary_path:
             self.boundary_path = boundary_path
@@ -748,6 +754,8 @@ class Raster(Grid):
             '--city_info',
             str(info),
             '--interactive',
+            '--dump_percent',
+            str(self.dump_percent),
         ]
         logger.info(f'Running {args}')
         if eval_folder:

--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -248,6 +248,8 @@ class Raster(Grid):
             raise ValueError('Tile size must be a multiple of 256' )
         if zoom is None:
             raise ValueError('Zoom level must be specified')
+        if tile_step & (tile_step - 1):
+            raise ValueError('Tile step must be a power of 2')
 
         self.zoom = zoom
         self.source = source

--- a/src/tile2net/tileseg/config.py
+++ b/src/tile2net/tileseg/config.py
@@ -59,7 +59,7 @@ __C.MODEL = AttrDict()
 __C.MODEL.SNAPSHOT = None
 # Where output results get written
 __C.RESULT_DIR = None
-__C.RESULT_PERCENT = None
+__C.DUMP_PERCENT = 0
 
 # Border Relaxation Count
 __C.BORDER_WINDOW = 1

--- a/src/tile2net/tileseg/config.py
+++ b/src/tile2net/tileseg/config.py
@@ -59,6 +59,7 @@ __C.MODEL = AttrDict()
 __C.MODEL.SNAPSHOT = None
 # Where output results get written
 __C.RESULT_DIR = None
+__C.RESULT_PERCENT = None
 
 # Border Relaxation Count
 __C.BORDER_WINDOW = 1

--- a/src/tile2net/tileseg/inference/__init__.py
+++ b/src/tile2net/tileseg/inference/__init__.py
@@ -64,11 +64,13 @@ from tile2net.raster.project import Project
 @commandline
 def inference(args: Namespace):
     # sys.stdin
-
-    if not os.path.exists(args.result_dir):
-        os.mkdir(args.result_dir)
-    assert os.path.exists(args.result_dir), 'Result directory does not exist'
-    logging.info(f'Inferencing. Segmentation results will be saved to {args.result_dir}')
+    if args.result_percent:
+        if not os.path.exists(args.result_dir):
+            os.mkdir(args.result_dir)
+        assert os.path.exists(args.result_dir), 'Result directory does not exist'
+        logging.info(f'Inferencing. Segmentation results will be saved to {args.result_dir}')
+    else:
+        logging.info('Inferencing. Segmentation results will not be saved.')
 
     # Project.resources.assets.weights.satellite_2021
     weights = Project.resources.assets.weights

--- a/src/tile2net/tileseg/inference/commandline.py
+++ b/src/tile2net/tileseg/inference/commandline.py
@@ -29,7 +29,7 @@ commandline = compose_left(
         '--result_dir', type=str,
     ),
     arg(
-        '--result_percent',
+        '--dump_percent',
         type=int,
         default=0,
         help='The percentage of segmentation results to save. 100 means all, 0 means none.',

--- a/src/tile2net/tileseg/inference/commandline.py
+++ b/src/tile2net/tileseg/inference/commandline.py
@@ -29,6 +29,12 @@ commandline = compose_left(
         '--result_dir', type=str,
     ),
     arg(
+        '--result_percent',
+        type=int,
+        default=0,
+        help='The percentage of segmentation results to save. 100 means all, 0 means none.',
+    ),
+    arg(
         '--assets_path', type=str,
     ),
     arg(
@@ -318,5 +324,5 @@ commandline = compose_left(
         '--interactive',
         action='store_true',
         help='tile2net is being run in interactive python'
-    )
+    ),
 )

--- a/src/tile2net/tileseg/utils/misc.py
+++ b/src/tile2net/tileseg/utils/misc.py
@@ -250,7 +250,7 @@ class ImageDumper():
         else:
             self.save_dir = os.path.join(cfg.RESULT_DIR, 'seg_results')
 
-        os.makedirs(self.save_dir, exist_ok=True)
+        # os.makedirs(self.save_dir, exist_ok=True)
 
         self.imgs_to_tensorboard = []
         self.imgs_to_webpage = []
@@ -308,10 +308,18 @@ class ImageDumper():
                 mask_pil.save(mask_fn)
                 to_tensorboard.append(self.visualize(mask_pil))
 
+    result_percent = 100    # first one always dumps
+
     def dump(self, dump_dict, val_idx, testing=None, grid=None):
+        if self.result_percent < 100:
+            return
+        self.result_percent -= 100
+        self.result_percent += cfg.RESULT_PERCENT
+
         if (val_idx % self.dump_frequency or cfg.GLOBAL_RANK != 0):
             return
 
+        os.makedirs(self.save_dir, exist_ok=True)
         colorize_mask_fn = cfg.DATASET_INST.colorize_mask
 
         for idx in range(len(dump_dict['input_images'])):

--- a/src/tile2net/tileseg/utils/misc.py
+++ b/src/tile2net/tileseg/utils/misc.py
@@ -295,6 +295,7 @@ class ImageDumper():
             return True, err_pil
         return False, err_pil
 
+    dump_percent = 100  # first one always dumps if args.dump_percent != 0
     def create_composite_image(self, input_image, prediction_pil, img_name):
         if not self.args.dump_percent:
             return
@@ -333,7 +334,6 @@ class ImageDumper():
                 mask_pil.save(mask_fn)
                 to_tensorboard.append(self.visualize(mask_pil))
 
-    dump_percent = 100  # first one always dumps
 
     def dump(self, dump_dict, val_idx, testing=None, grid=None):
 

--- a/src/tile2net/tileseg/utils/misc.py
+++ b/src/tile2net/tileseg/utils/misc.py
@@ -43,6 +43,7 @@ from tabulate import tabulate
 from PIL import Image
 
 from tile2net.tileseg.config import cfg
+from tile2net.namespace import Namespace
 
 from runx.logx import logx
 
@@ -208,10 +209,24 @@ class ImageDumper():
     converts them to images (doing transformations where necessary) and then
     writes the images out to disk.
     """
-    def __init__(self, val_len, tensorboard=True, write_webpage=True,
-                 webpage_fn='index.html', dump_all_images=False, dump_assets=False,
-                 dump_err_prob=False, dump_num=10, dump_for_auto_labelling=False,
-                 dump_for_submission=False):
+
+    # def __init__(self, val_len, args: Namespace, tensorboard=True, write_webpage=True,
+    #              webpage_fn='index.html', dump_all_images=False, dump_assets=False,
+    #              dump_err_prob=False, dump_num=10, dump_for_auto_labelling=False,
+    #              dump_for_submission=False):
+    def __init__(
+            self,
+            val_len,
+            args: Namespace,
+            tensorboard=True,
+            write_webpage=True,
+            webpage_fn='index.html',
+            dump_all_images=False,
+            dump_assets=False,
+            dump_for_auto_labelling=False,
+            dump_for_submission=False,
+            dump_num=10,
+    ):
         """
         :val_len: num validation images
         :tensorboard: push summary to tensorboard
@@ -231,10 +246,10 @@ class ImageDumper():
         self.dump_for_submission = dump_for_submission
 
         self.viz_frequency = max(1, val_len // dump_num)
-        if dump_all_images:
-            self.dump_frequency = 1
-        else:
-            self.dump_frequency = self.viz_frequency
+        # if dump_all_images:
+        #     self.dump_frequency = 1
+        # else:
+        #     self.dump_frequency = self.viz_frequency
 
         inv_mean = [-mean / std for mean, std in zip(cfg.DATASET.MEAN,
                                                      cfg.DATASET.STD)]
@@ -259,7 +274,8 @@ class ImageDumper():
             standard_transforms.Resize(384),
             standard_transforms.CenterCrop((384, 384)),
             standard_transforms.ToTensor()
-            ])
+        ])
+        self.args = args
 
     def reset(self):
         self.imgs_to_tensorboard = []
@@ -280,11 +296,20 @@ class ImageDumper():
         return False, err_pil
 
     def create_composite_image(self, input_image, prediction_pil, img_name):
+        if not self.args.dump_percent:
+            return
+        self.dump_percent += self.args.dump_percent
+        if self.dump_percent < 100:
+            return
+        self.dump_percent -= 100
+        parent = os.path.dirname(self.save_dir)
+        os.makedirs(parent, exist_ok=True)
         composited = Image.new('RGB', (input_image.width + input_image.width, input_image.height))
         composited.paste(input_image, (0, 0))
         composited.paste(prediction_pil, (prediction_pil.width, 0))
         composited_fn = 'sidebside_{}.png'.format(img_name)
         composited_fn = os.path.join(self.save_dir, composited_fn)
+        print(f'saving {composited_fn}')
         composited.save(composited_fn)
 
     def get_dump_assets(self, dump_dict, img_name, idx, colorize_mask_fn, to_tensorboard):
@@ -308,21 +333,16 @@ class ImageDumper():
                 mask_pil.save(mask_fn)
                 to_tensorboard.append(self.visualize(mask_pil))
 
-    result_percent = 100    # first one always dumps
+    dump_percent = 100  # first one always dumps
 
     def dump(self, dump_dict, val_idx, testing=None, grid=None):
-        if self.result_percent < 100:
-            return
-        self.result_percent -= 100
-        self.result_percent += cfg.RESULT_PERCENT
 
-        if (val_idx % self.dump_frequency or cfg.GLOBAL_RANK != 0):
-            return
-
-        os.makedirs(self.save_dir, exist_ok=True)
+        # if not self.args.dump_percent:
+        #     return
         colorize_mask_fn = cfg.DATASET_INST.colorize_mask
 
         for idx in range(len(dump_dict['input_images'])):
+
             input_image = dump_dict['input_images'][idx]
             gt_image = dump_dict['gt_images'][idx]
             prediction = dump_dict['assets']['predictions'][idx]
@@ -353,7 +373,7 @@ class ImageDumper():
                 else:
                     prediction_pil = colorize_mask_fn(prediction)
                     prediction_pil = prediction_pil.convert('RGB')
-                    # self.create_composite_image(input_image, prediction_pil, img_name)
+                    self.create_composite_image(input_image, prediction_pil, img_name)
 
                     if grid:
                         idd_ = img_name.split('_')[-1]
@@ -368,9 +388,6 @@ class ImageDumper():
                 prediction_pil = prediction_pil.convert('RGB')
                 self.create_composite_image(input_image, prediction_pil, img_name)
 
-            if val_idx % self.viz_frequency or cfg.GLOBAL_RANK != 0:
-                return
-
             to_tensorboard = [
                 self.visualize(input_image.convert('RGB')),
                 self.visualize(gt_pil.convert('RGB')),
@@ -382,8 +399,6 @@ class ImageDumper():
             self.get_dump_assets(dump_dict, img_name, idx, colorize_mask_fn, to_tensorboard)
 
             self.imgs_to_tensorboard.append(to_tensorboard)
-
-
 
     def write_summaries(self, was_best):
         """
@@ -435,7 +450,7 @@ def print_evaluate_results(hist, iu, epoch=0, iou_per_scale=None,
     iu_FP = hist.sum(axis=1) - np.diag(hist)
     iu_FN = hist.sum(axis=0) - np.diag(hist)
     iu_TP = np.diag(hist)
-    #save the default hist
+    # save the default hist
     np.save(f'{cfg.RESULT_DIR}/cm_{epoch}.npy', hist)
     logx.msg('IoU:')
 
@@ -471,10 +486,11 @@ def print_evaluate_results(hist, iu, epoch=0, iou_per_scale=None,
     print_str = str(tabulate((tabulate_data), headers=header, floatfmt='1.2f'))
     logx.msg(print_str)
 
-    #save the histogram in a table :
+    # save the histogram in a table :
     class_names = ["{}".format(id2cat[class_id]) if class_id in id2cat else '' for class_id in range(len(iu))]
     df_cm = pd.DataFrame(hist, index=class_names, columns=class_names)
     df_cm.to_csv(f'{cfg.RESULT_DIR}/histogram_{epoch}.csv')
+
 
 def metrics_per_image(hist):
     """


### PR DESCRIPTION
Added commandline arg `result_percent` with default = 0 to describe the percentage of images that should be dumped:
```    result_percent = 100    # first one always dumps

    def dump(self, dump_dict, val_idx, testing=None, grid=None):
        if self.result_percent < 100:
            return
        self.result_percent -= 100
        self.result_percent += cfg.RESULT_PERCENT

        if (val_idx % self.dump_frequency or cfg.GLOBAL_RANK != 0):
            return

        os.makedirs(self.save_dir, exist_ok=True)
        colorize_mask_fn = cfg.DATASET_INST.colorize_mask

```
this is available as `cfg.RESULT_PERCENT` or `args.result_percent`. Removed `mkdir` from `ImageDumper.__init__`

Asserted tile_step power of 2 in `Raster.__init__`:
```        if tile_step & (tile_step - 1):
            raise ValueError('Tile step must be a power of 2')
```

Inference only calls mkdir if result_percent:
```
@commandline
def inference(args: Namespace):
    # sys.stdin
    if args.result_percent:
        if not os.path.exists(args.result_dir):
            os.mkdir(args.result_dir)
        assert os.path.exists(args.result_dir), 'Result directory does not exist'
        logging.info(f'Inferencing. Segmentation results will be saved to {args.result_dir}')
    else:
        logging.info('Inferencing. Segmentation results will not be saved.')

```

