### PR TITLE
Fix black tile size and remove tile_step from BaseGrid

### DIFF
--- a/examples/inference.ipynb
+++ b/examples/inference.ipynb
@@ -78,7 +78,8 @@
     "collapsed": false
    },
    "source": [
-    "You may also instantiate a Raster using a local directory of tiles, given that an arbitrary directory structure e.g. `path/to/tiles/z/x/y.ext` or `path/to/tiles/z/x_y.ext` is defined. The `z` for `zoom` may or may not be included in the path, but `zoom` must be passed to the Raster arguments."
+    "You may also instantiate a Raster using a local directory of tiles, given that an arbitrary directory structure e.g. `path/to/tiles/z/x/y.ext` or `path/to/tiles/z/x_y.ext` is defined. \n",
+    "The `z` for `zoom` may or may not be included in the path, but `zoom` must be passed to the Raster arguments."
    ]
   },
   {
@@ -104,7 +105,8 @@
     "collapsed": false
    },
    "source": [
-    "Without specifying `input_dir`, Raster will determine the most suitable tile source for the location:"
+    "Without specifying `input_dir`, Raster will determine the most suitable tile source for the location, if the region is suppored. \n",
+    "If the region is not supported, you can still create a Raster object for your region to work with for some basic tasks but you wont be able to download tile and generate network. "
    ]
   },
   {
@@ -216,7 +218,8 @@
    },
    "source": [
     "### Inference\n",
-    "Now that the tiles have been stitched together, we can run an inference on the stitched images."
+    "Now that the tiles have been stitched together, we can run an inference on the stitched images. \n",
+    "You can use the dump_percent parameter to specify the percentage of segmentation images to save to the subdirectory 'segmentation/seg_results'. 100 means all, 0 means none. The default is 0."
    ]
   },
   {
@@ -227,7 +230,7 @@
    },
    "outputs": [],
    "source": [
-    "raster.inference()"
+    "raster.inference(dump_percent=20)"
    ]
   }
  ],

--- a/src/tile2net/raster/grid.py
+++ b/src/tile2net/raster/grid.py
@@ -134,7 +134,6 @@ class BaseGrid(BaseRegion):
     zoom: int = field(default=19)
     base_tilesize: int = field(default=256)
     padding: bool = field(default=True, repr=False)
-    tile_step: int = field(default=1, repr=False)
     tiles: np.ndarray = field(default_factory=lambda: np.array(Tile), init=False, repr=False)
 
     def __post_init__(self):
@@ -148,18 +147,18 @@ class BaseGrid(BaseRegion):
                     self.xtile + col_idx,
                     self.ytile + row_idx,
                     position=(
-                        int(col_idx / self.tile_step), int(row_idx / self.stitch_step)
+                        int(col_idx), int(row_idx)
                     ),
                     idd=self.pos2id(
-                        int(col_idx / self.tile_step), int(row_idx / self.stitch_step)
+                        int(col_idx), int(row_idx)
                     ),
                     zoom=self.zoom,
-                    size=self.tile_size,
+                    size=self.base_tilesize,
                     crs=self.crs
                 )
-                for row_idx in np.arange(0, self.base_height, self.tile_step)
+                for row_idx in np.arange(0, self.base_height)
             ]
-            for col_idx in np.arange(0, self.base_width, self.tile_step)
+            for col_idx in np.arange(0, self.base_width)
         ])
         self.pose_dict = {tile.idd: tile.position for col in self.tiles for tile in col}
         # due to the rounding issues with deg2num and num2deg, we do this calculation again
@@ -185,9 +184,6 @@ class BaseGrid(BaseRegion):
     def base_width(self):
         return abs(self.xtilem - self.xtile) + 1  # horizontal tiles (#columns)
 
-    @cached_property
-    def tile_size(self):
-        return self.base_tilesize * self.stitch_step
 
     def pos2id(self, col_idx: int, row_idx: int):
         """

--- a/src/tile2net/raster/pednet.py
+++ b/src/tile2net/raster/pednet.py
@@ -2,6 +2,7 @@ import logging
 import datetime
 import pandas as pd
 import os
+
 os.environ['USE_PYGEOS'] = '0'
 import geopandas as gpd
 
@@ -137,37 +138,6 @@ class PedNet():
         merged = shapely.ops.linemerge(new_l)
         return merged
 
-    def update_sw_intersecting(self, cw_pol):
-        """
-        Cleans up sidewalk lines extending over crosswalks polygons and cut them
-
-        Parameters
-        ----------
-        cw_pol : :class:`gpd.GeoDataFrame`
-            :class:`GeoDataFrame` of crosswalks
-        """
-        # finding sidewalk lines that extends to the crosswalks polygons and cut them
-        swl = self.sidewalk.copy()
-        swl = swl.reset_index(drop=True).explode().reset_index(drop=True)
-        # print(swl.head(10))
-        cwrect = [i.minimum_rotated_rectangle for i in cw_pol.geometry]
-        cwrectgdf = geo2geodf(cwrect)
-
-        cwin, swin = swl.geometry.values.sindex.query_bulk(cwrectgdf.geometry.values,
-                                                           predicate="intersects")
-        indsect = list(zip(cwin, swin))
-        inds = []
-        updated_geom = []
-        for v, k in indsect:
-            if swl.iloc[k, 1].intersects(cwrectgdf.iloc[v, 0]):
-                inds.append(k)
-                updated_geom.append(
-                    swl.iloc[k, swl.columns.get_loc(swl.geometry.name)].difference(
-                        cwrectgdf.iloc[v, 0]))
-        swl.iloc[inds, swl.columns.get_loc(swl.geometry.name)] = updated_geom
-        smoothed = wrinkle_remover(swl, 1)
-        self.sidewalk = smoothed
-
     def create_crosswalk(self):
         """
         Create crosswalks centerlines from polygons
@@ -184,27 +154,24 @@ class PedNet():
             cw_explode = cw_union.explode().reset_index(drop=True)
             cw_explode = cw_explode[cw_explode.geometry.notna()].reset_index(drop=True)
             cw_explode_ = morpho_atts(cw_explode)
-            polak = []
             for c, geom in enumerate(cw_explode_.geometry):
                 if geom.area < 5:
                     continue
                     # logging.info(c, 'continue')
                 else:
                     # if crosswalks are attached to each other and form a T or U
-                    if cw_explode_.iloc[
-                        c, cw_explode_.columns.get_loc(cw_explode_.convexity.name)] < 0.8:
+                    if cw_explode_.iloc[c, cw_explode_.columns.get_loc(cw_explode_.convexity.name)] < 0.8:
                         av_width = 4 * geom.area / geom.length
                         geom_er = geom.buffer(-av_width / 4)
-                        polak.append(geom_er)
                         if geom_er.type == "MultiPolygon":
                             for g in list(geom_er.geoms):  # shapely 2
                                 if g.area > 2:
                                     cnl = to_cline(g, 0.3, 1)
                                     tr_line_ = trim_checkempty(cnl, 4.5, 2)
-                                    if tr_line_.length < 6:
-                                        extended = self.make_longer(tr_line_, 3/4)
+                                    if tr_line_.length < 8:
+                                        extended = self.make_longer(tr_line_, 0.8)
                                         extended_line = extend_lines(geo2geodf([extended]),
-                                                                     tolerance=5,
+                                                                     tolerance=8,
                                                                      target=geo2geodf([geom.boundary]), extension=0)
                                         for gi in extended_line.geometry:
                                             cw_lin_geom.append(gi)
@@ -214,13 +181,12 @@ class PedNet():
                                     continue
                         elif geom_er.type == "Polygon":
                             if geom_er.area > 2:
-                                # print(geom_er.type, geom_er.area)
                                 cnl = to_cline(geom_er, 0.2, 1)
                                 tr_line_ = trim_checkempty(cnl, 4.5, 2)
-                                if tr_line_.length < 6:
-                                    extended = self.make_longer(tr_line_, 3 / 4)
+                                if tr_line_.length < 8:
+                                    extended = self.make_longer(tr_line_, 0.8)
                                     extended_line = extend_lines(geo2geodf([extended]),
-                                                                 target=geo2geodf([geom.boundary]), tolerance=5,
+                                                                 target=geo2geodf([geom.boundary]), tolerance=8,
                                                                  extension=0)
                                     for g in extended_line.geometry:
                                         cw_lin_geom.append(g)
@@ -231,26 +197,20 @@ class PedNet():
                         else:
                             continue
                     else:
-                        polak.append(geom)
                         line = get_crosswalk_cnl(geom)
-                        if line.length < 6:
-                            extended = self.make_longer(line, 3 / 4)
+                        if line.length < 8:
+                            extended = self.make_longer(line, 0.8)
                             extended_line = extend_lines(geo2geodf([extended]),
-                                                         target=geo2geodf([geom.boundary]), tolerance=5, extension=0)
+                                                         target=geo2geodf([geom.boundary]), tolerance=8, extension=0)
                             for g in extended_line.geometry:
                                 cw_lin_geom.append(g)
                         else:
                             cw_lin_geom.append(line)
 
-            cwpol = gpd.GeoDataFrame(geometry=polak)
-            cwpol.geometry = cwpol.geometry.set_crs(3857)
-
-            self.update_sw_intersecting(cwpol)
-
             cw_ntw = geo2geodf(cw_lin_geom)
             cw_ntw['f_type'] = 'crosswalk'
             cw_ntw.geometry = cw_ntw.geometry.set_crs(3857)
-            smoothed = wrinkle_remover(cw_ntw, 1.2)
+            smoothed = wrinkle_remover(cw_ntw, 1.3)
             self.crosswalk = smoothed
 
     def create_lines(self, gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -330,20 +290,14 @@ class PedNet():
         None
         """
         sw_all = self.prepare_class_gdf('sidewalk')
-        cwp = self.prepare_class_gdf('crosswalk')
 
         if len(sw_all) > 0:
-            # sw_filtered = self.find_medianisland(sw_all, cwp)
-            # if not isinstance(sw_filtered, int):
-            #     swntw = self.create_lines(sw_filtered)  # union_df
-            # else:
-            #     swntw = self.create_lines(sw_all)  # swuinon_df
             swntw = self.create_lines(sw_all)
             logging.info('..... creating the processed sidewalk network')
             #
             swntw.geometry = swntw.simplify(0.6)
             sw_modif_uni = gpd.GeoDataFrame(
-                geometry=gpd.GeoSeries([geom for geom in swntw.unary_union.geoms]))
+                    geometry=gpd.GeoSeries([geom for geom in swntw.unary_union.geoms]))
             sw_modif_uni_met = set_gdf_crs(sw_modif_uni, 3857)
             sw_uni_lines = sw_modif_uni_met.explode()
             sw_uni_lines.reset_index(drop=True, inplace=True)
@@ -380,7 +334,7 @@ class PedNet():
 
         # query LineString geometry to identify points intersecting 2 geometries
         inp, res = self.crosswalk.sindex.query(geo2geodf(points).geometry,
-                                                    predicate="intersects")
+                                               predicate="intersects")
         unique, counts = np.unique(inp, return_counts=True)
         ends = np.unique(res[np.isin(inp, unique[counts == 1])])
 
@@ -413,7 +367,7 @@ class PedNet():
         # create a dataframe of points
         if len(new_geoms_s) > 0:
             ps = [g[1] for g in new_geoms_s]
-            ls = [g[0] for g in new_geoms_s]
+            # ls = [g[0] for g in new_geoms_s]
             pdfs = gpd.GeoDataFrame(geometry=ps)
             pdfs.set_crs(3857, inplace=True)
 
@@ -422,7 +376,7 @@ class PedNet():
 
         if len(new_geoms_e) > 0:
             pe = [g[1] for g in new_geoms_e]
-            le = [g[0] for g in new_geoms_e]
+            # le = [g[0] for g in new_geoms_e]
             pdfe = gpd.GeoDataFrame(geometry=pe)
             pdfe.set_crs(3857, inplace=True)
 
@@ -431,14 +385,13 @@ class PedNet():
 
         if len(new_geoms_both) > 0:
             pb = [g[1] for g in new_geoms_both]
-            lb = [g[0] for g in new_geoms_both]  # crosswalk lines where both ends do not intersect
+            # lb = [g[0] for g in new_geoms_both]  # crosswalk lines where both ends do not intersect
             pdfb = gpd.GeoDataFrame(geometry=pb)
             pdfb.set_crs(3857, inplace=True)
 
             connect_b = get_shortest(self.sidewalk, pdfb, f_type='sidewalk_connection')
             all_connections.append(connect_b)
         if len(all_connections) > 1:
-
             connect = pd.concat(all_connections)
         elif len(all_connections) == 1:
             connect = all_connections[0]
@@ -456,8 +409,8 @@ class PedNet():
 
                 for k, v in indcwnear:
                     island_lines.append(
-                        shapely.shortest_line(self.island.geometry.values[v],
-                                              pdfb.geometry.values[k]))
+                            shapely.shortest_line(self.island.geometry.values[v],
+                                                  pdfb.geometry.values[k]))
 
                 island = gpd.GeoDataFrame(geometry=island_lines)
 
@@ -474,12 +427,13 @@ class PedNet():
         combined.geometry = combined.geometry.set_crs(3857)
         combined.geometry = combined.geometry.to_crs(4326)
         combined = combined[~combined.geometry.isna()]
+        combined.drop_duplicates(subset='geometry', inplace=True)
         combined.reset_index(drop=True, inplace=True)
         path = self.project.network.path
 
         path.mkdir(parents=True, exist_ok=True)
         path = path.joinpath(
-            f'{self.project.name}-Network-{datetime.datetime.now().strftime("%d-%m-%Y_%H")}'
+                f'{self.project.name}-Network-{datetime.datetime.now().strftime("%d-%m-%Y_%H")}'
         )
         combined.to_file(path)
 

--- a/src/tile2net/raster/pednet.py
+++ b/src/tile2net/raster/pednet.py
@@ -154,6 +154,7 @@ class PedNet():
             cw_explode = cw_union.explode().reset_index(drop=True)
             cw_explode = cw_explode[cw_explode.geometry.notna()].reset_index(drop=True)
             cw_explode_ = morpho_atts(cw_explode)
+            # polak = []
             for c, geom in enumerate(cw_explode_.geometry):
                 if geom.area < 5:
                     continue
@@ -163,6 +164,7 @@ class PedNet():
                     if cw_explode_.iloc[c, cw_explode_.columns.get_loc(cw_explode_.convexity.name)] < 0.8:
                         av_width = 4 * geom.area / geom.length
                         geom_er = geom.buffer(-av_width / 4)
+                        # polak.append(geom_er)
                         if geom_er.type == "MultiPolygon":
                             for g in list(geom_er.geoms):  # shapely 2
                                 if g.area > 2:
@@ -197,6 +199,7 @@ class PedNet():
                         else:
                             continue
                     else:
+                        # polak.append(geom)
                         line = get_crosswalk_cnl(geom)
                         if line.length < 8:
                             extended = self.make_longer(line, 0.8)

--- a/src/tile2net/raster/project.py
+++ b/src/tile2net/raster/project.py
@@ -187,7 +187,6 @@ class Segmentation(Directory):
         if tiles is None:
             tiles = self.project.raster.tiles
         path = self.path
-        path.mkdir(parents=True, exist_ok=True)
         path = path.__fspath__()
         R, C = np.meshgrid(
             np.arange(tiles.shape[0]),

--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -959,3 +959,4 @@ if __name__ == '__main__':
     )
     raster.generate(2)
     raster.inference()
+

--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -72,7 +72,7 @@ class Black:
 
     @cached_property
     def array(self):
-        return np.zeros((self.owner.base_tilesize, self.owner.base_tilesize, 3), dtype=np.uint8)
+        return np.zeros((self.owner.tile_size, self.owner.tile_size, 3), dtype=np.uint8)
 
 
 class Raster(Grid):

--- a/src/tile2net/tileseg/inference/inference.py
+++ b/src/tile2net/tileseg/inference/inference.py
@@ -451,7 +451,7 @@ class LocalInference(Inference):
 
     def validate(self, *args, grid: Raster, **kwargs):
         # as a temporary solution just assign the segmentation path to the tile
-        grid.project.resources.segmentation.path.mkdir(exist_ok=True, parents=True)
+        # grid.project.resources.segmentation.path.mkdir(exist_ok=True, parents=True)
         for segmentation, tile in zip(
                 grid.project.resources.segmentation.files(),
                 grid.tiles.ravel(),

--- a/src/tile2net/tileseg/utils/misc.py
+++ b/src/tile2net/tileseg/utils/misc.py
@@ -373,6 +373,7 @@ class ImageDumper:
                 mask = mask.astype(np.uint8)
                 mask_pil = Image.fromarray(mask)
                 mask_pil = mask_pil.convert('RGB')
+                os.makedirs(self.save_dir, exist_ok=True)
                 mask_pil.save(mask_fn)
                 to_tensorboard.append(self.visualize(mask_pil))
 
@@ -578,7 +579,7 @@ class ThreadedDumper(ImageDumper):
         super().__init__(*args, **kwargs)
         self.futures: list[Future] = []
         self.threads = ThreadPoolExecutor()
-        os.makedirs(self.save_dir, exist_ok=True)
+        # os.makedirs(self.save_dir, exist_ok=True)
 
     def dump(self, dump_dict, val_idx, testing=None, grid=None):
 
@@ -665,6 +666,7 @@ class ThreadedDumper(ImageDumper):
         composited.paste(prediction_pil, (prediction_pil.width, 0))
         composited_fn = 'sidebside_{}.png'.format(img_name)
         composited_fn = os.path.join(self.save_dir, composited_fn)
+        os.makedirs(self.save_dir, exist_ok=True)
         # print(f'saving {composited_fn}')
         # composited.save(composited_fn)
         future = threads.submit(composited.save, composited_fn)


### PR DESCRIPTION
This PR fixes the issue with the size of black tiles that are used cross Raster, to be the same size as the Grid's tile instead of always defaulting to 256. 
I also removed the tile_step attribute from BaseGrid since BaseGrid should always reflect the Slippy Tile Map grid. 
The inference notebook is also updated with some extra explanation including adding dump_percent argument. 

