### PR TITLE
add year and server to info json

### DIFF
--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -767,25 +767,25 @@ class Raster(Grid):
             return_dict : bool
                 whether or not to return the updated grid info as a dict instead of saving to a json file
         """
-        city_info = {
-            "name": self.name,
-            "bbox": self.bbox,
-            "location": self.location,
-            "size": self.tile_size,
-            "zoom": self.zoom,
-            "crs": self.crs,
-            "tile_step": self.tile_step,
-            "project": dict(self.project.structure),
-            'debug': self.debug,
-        }
-        if self.source:
-            city_info["source"] = str(self.source)
+        city_info = dict(
+            name=self.name,
+            bbox=self.bbox,
+            location=self.location,
+            size=self.tile_size,
+            zoom=self.zoom,
+            crs=self.crs,
+            tile_step=self.tile_step,
+            project=dict(self.project.structure),
+            debug=self.debug,
+        )
         if self.output_dir:
             city_info["output_dir"] = str(self.output_dir)
         if self.input_dir:
             city_info["input_dir"] = str(self.input_dir)
         if self.source:
             city_info["source"] = str(self.source)
+            city_info["year"] = self.source.year
+            city_info['server'] = self.source.server
 
         if "new_tstep" in kwargs:
             city_info["size"] = self.tile_size * kwargs["new_tstep"]

--- a/src/tile2net/raster/source.py
+++ b/src/tile2net/raster/source.py
@@ -210,6 +210,7 @@ class Source(ABC, metaclass=SourceMeta):
     tilesize: int = 256  # pixels per tile side
     keyword: str  # required match when reverse geolocating address from point
     dropword: str = None  # if result contains this word, it is not a match
+    year: int = None  # year of the data
 
     def __getitem__(self, item: Iterator[Tile]):
         tiles = self.tiles
@@ -354,12 +355,14 @@ class NewYorkCity(ArcGis):
     server = 'https://tiles.arcgis.com/tiles/yG5s3afENB5iO9fj/arcgis/rest/services/NYC_Orthos_-_2020/MapServer'
     name = 'nyc'
     keyword = 'New York City', 'City of New York'
+    year =  2020
 
 
 class NewYork(ArcGis):
     server = 'https://orthos.its.ny.gov/arcgis/rest/services/wms/2020/MapServer'
     name = 'ny'
     keyword = 'New York'
+    year = 2020
 
 
 class Massachusetts(ArcGis):
@@ -367,12 +370,14 @@ class Massachusetts(ArcGis):
     name = 'ma'
     keyword = 'Massachusetts'
     extension = 'jpg'
+    year = 2019
 
 
 class KingCountyWashington(ArcGis):
     server = 'https://gismaps.kingcounty.gov/arcgis/rest/services/BaseMaps/KingCo_Aerial_2021/MapServer'
     name = 'king'
     keyword = 'King County, Washington', 'King County'
+    year = 2021
 
 
 class WashingtonDC(ArcGis):
@@ -382,6 +387,7 @@ class WashingtonDC(ArcGis):
     tilesize = 512
     extension = 'jpeg'
     keyword = 'District of Columbia', 'DC'
+    year = 2021
 
     def __getitem__(self, item: Iterator[Tile]):
         for tile in item:
@@ -402,6 +408,7 @@ class LosAngeles(ArcGis):
     server = 'https://cache.gis.lacounty.gov/cache/rest/services/LACounty_Cache/LACounty_Aerial_2014/MapServer'
     name = 'la'
     keyword = 'Los Angeles'
+    year = 2014
 
     # to test case where a source raises an error due to metadata failure
     #   other sources should still function
@@ -440,12 +447,14 @@ class NewJersey(ArcGis):
     server = 'https://maps.nj.gov/arcgis/rest/services/Basemap/Orthos_Natural_2020_NJ_WM/MapServer'
     name = 'nj'
     keyword = 'New Jersey'
+    year = 2020
 
 
 class SpringHillTN(ArcGis):
     server = 'https://tiles.arcgis.com/tiles/tF0XsRR9ptiKNVW2/arcgis/rest/services/Spring_Hill_Imagery_WGS84/MapServer'
     name = 'sh_tn'
     keyword = 'Spring Hill, Tennessee', 'Spring Hill'
+    year = 2020
 
 
 class Virginia(ArcGis):

--- a/src/tile2net/tileseg/inference/inference.py
+++ b/src/tile2net/tileseg/inference/inference.py
@@ -64,13 +64,21 @@ from tile2net.tileseg.loss.utils import get_loss
 from tile2net.tileseg.utils.misc import AverageMeter, prep_experiment
 from tile2net.tileseg.utils.misc import ImageDumper, ThreadedDumper
 from tile2net.tileseg.utils.trnval_utils import eval_minibatch
+from tile2net.raster.project import Project
+if False:
+    from tile2net.raster.raster import Raster
+import hashlib
+
+def sha256sum(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
 
 sys.path.append(os.environ.get('SUBMIT_SCRIPTS', '.'))
 AutoResume = None
 
-from tile2net.raster.project import Project
-if False:
-    from tile2net.raster.raster import Raster
 
 
 class Inference:
@@ -165,12 +173,18 @@ class Inference:
         if args.model.snapshot:
             if 'ASSETS_PATH' in args.model.snapshot:
                 args.model.snapshot = args.model.snapshot.replace('ASSETS_PATH', cfg.ASSETS_PATH)
-            add_safe_globals([
-                np.core.multiarray.scalar,
-                np.dtype,
-                Float16DType, Float32DType, Float64DType,  # blocklisted DTypeMeta subclasses
-            ])
-            checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'))
+
+            # Compute and validate checksum
+            expected_checksum = '745f8c099e98f112a152aedba493f61fb6d80c1761e5866f936eb5f361c7ab4d'
+            actual_checksum = sha256sum(args.model.snapshot)
+            if actual_checksum != expected_checksum:
+                raise RuntimeError(f"Checksum mismatch: expected {expected_checksum}, got {actual_checksum}")
+
+            checkpoint = torch.load(
+                args.model.snapshot,
+                map_location='cpu',
+                weights_only=False,
+            )
             args.restore_net = True
             msg = "Loading weights from: checkpoint={}".format(args.model.snapshot)
             logger.info(msg)

--- a/src/tile2net/tileseg/inference/inference.py
+++ b/src/tile2net/tileseg/inference/inference.py
@@ -47,6 +47,9 @@ import torch.distributed as dist
 from geopandas import GeoDataFrame
 from torch.utils.data import DataLoader
 from typing import Optional
+import numpy as np
+from numpy.dtypes import Float16DType, Float32DType, Float64DType
+from torch.serialization import add_safe_globals
 
 import tile2net.tileseg.network.ocrnet
 from tile2net.logger import logger
@@ -162,6 +165,11 @@ class Inference:
         if args.model.snapshot:
             if 'ASSETS_PATH' in args.model.snapshot:
                 args.model.snapshot = args.model.snapshot.replace('ASSETS_PATH', cfg.ASSETS_PATH)
+            add_safe_globals([
+                np.core.multiarray.scalar,
+                np.dtype,
+                Float16DType, Float32DType, Float64DType,  # blocklisted DTypeMeta subclasses
+            ])
             checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'))
             args.restore_net = True
             msg = "Loading weights from: checkpoint={}".format(args.model.snapshot)

--- a/src/tile2net/tileseg/inference/inference.py
+++ b/src/tile2net/tileseg/inference/inference.py
@@ -49,7 +49,7 @@ from torch.utils.data import DataLoader
 from typing import Optional
 import numpy as np
 from numpy.dtypes import Float16DType, Float32DType, Float64DType
-from torch.serialization import add_safe_globals
+from torch.serialization import add_safe_globals, safe_globals
 
 import tile2net.tileseg.network.ocrnet
 from tile2net.logger import logger
@@ -170,7 +170,7 @@ class Inference:
                 np.dtype,
                 Float16DType, Float32DType, Float64DType,  # blocklisted DTypeMeta subclasses
             ])
-            checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'), weights_only=True)
+            checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'))
             args.restore_net = True
             msg = "Loading weights from: checkpoint={}".format(args.model.snapshot)
             logger.info(msg)

--- a/src/tile2net/tileseg/inference/inference.py
+++ b/src/tile2net/tileseg/inference/inference.py
@@ -170,7 +170,7 @@ class Inference:
                 np.dtype,
                 Float16DType, Float32DType, Float64DType,  # blocklisted DTypeMeta subclasses
             ])
-            checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'))
+            checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'), weights_only=True)
             args.restore_net = True
             msg = "Loading weights from: checkpoint={}".format(args.model.snapshot)
             logger.info(msg)


### PR DESCRIPTION
now the json contains e.g.:
```
    "year": 2019,
    "server": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/USGS_Orthos_2019/MapServer"
```
However the test will likely fail. This line:
```            checkpoint = torch.load(args.model.snapshot, map_location=torch.device('cpu'))```
results in this error:
```
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray.scalar was not an allowed global by default. Please use `torch.serialization.add_safe_globals([scalar])` or the `torch.serialization.safe_globals([scalar])` context manager to allowlist this global if you trust this class/function.
```