### PR TITLE
san francisco and fix download max_workers

### DIFF
--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -616,7 +616,7 @@ class Raster(Grid):
         None
         """
         with (
-            ThreadPoolExecutor(max_workers=5) as threads,
+            ThreadPoolExecutor() as threads,
             requests.Session() as session,
         ):
             if not self.source:

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -29,6 +29,7 @@ def test_sources():
                 or not issubclass(cls, Source)
                 or abc.ABC in cls.__bases__
                 or getattr(cls, 'ignore', False)
+                or cls.outdated
         ):
             continue
         # assert querying by the polygon returns the same source


### PR DESCRIPTION
Our downloading was remarkably slow compared to the new version I am working on. In our `Raster.download` method, max_workers was set to 5. I've removed this.
```
    def download(self, retry: bool = True):
        """
        Download tiles from the source.

        Parameters
        ----------
        retry : bool
            When True, tries to serialize tiles a second time if the first time fails
        Returns
        -------
        None
        """
        with (
            ThreadPoolExecutor(max_workers=5) as threads,
            requests.Session() as session,
        ):

```

I've added the various rgb8cm years for the San Francisco tiles:
```

class SanFrancisco2014(SanFranciscoBase):
    name = 'sf2014'
    year = 2014
    server = 'https://tile.sf.gov/api/tiles/p2014_rgb8cm'


class SanFrancisco2017(SanFranciscoBase):
    name = 'sf2017'
    year = 2017
    server = 'https://tile.sf.gov/api/tiles/p2017_rgb8cm'


class SanFrancisco2018(SanFranciscoBase):
    name = 'sf2018'
    year = 2018
    server = 'https://tile.sf.gov/api/tiles/p2018_rgb8cm'


class SanFrancisco2019(SanFranciscoBase):
    name = 'sf2019'
    year = 2019
    server = 'https://tile.sf.gov/api/tiles/p2019_rgb8cm'


class SanFrancisco2020(SanFranciscoBase):
    name = 'sf2020'
    year = 2020
    server = 'https://tile.sf.gov/api/tiles/p2020_rgb8cm'


class SanFrancisco2023(SanFranciscoBase):
    name = 'sf2023'
    year = 2023
    server = 'https://tile.sf.gov/api/tiles/p2023_rgb8cm'


class SanFrancisco2024(SanFranciscoBase):
    name = 'sf2024'
    year = 2024
    server = 'https://tile.sf.gov/api/tiles/p2024_rgb8cm'
    outdated = False

```
There is now an `outdated` class attribute. If it's True, it won't show up in the geometric coverage. However, it will still show up in the `Source` catalog. 

There's some sort of park in San Francisco next to the big bridge. I decided to check it out:
![image](https://github.com/user-attachments/assets/0bac644e-08e3-4442-8de9-8a0661499a26)
