### PR TITLE
Maine

### DIFF
--- a/src/tile2net/raster/raster.py
+++ b/src/tile2net/raster/raster.py
@@ -623,8 +623,16 @@ class Raster(Grid):
                 return
             self.project.tiles.static.path.mkdir(parents=True, exist_ok=True)
 
-            paths = np.fromiter(self.project.tiles.static.files(), dtype=object, count=self.tiles.size)
-            urls = np.fromiter(self.source[self.tiles.flat], dtype=object, count=self.tiles.size)
+            paths = np.fromiter(
+                self.project.tiles.static.files(),
+                dtype=object,
+                count=self.tiles.size
+            )
+            urls = np.fromiter(
+                self.source[self.tiles.ravel()],
+                dtype=object,
+                count=self.tiles.size
+            )
             loc = [
                 not os.path.exists(path)
                 for path in paths

--- a/src/tile2net/raster/source.py
+++ b/src/tile2net/raster/source.py
@@ -693,6 +693,7 @@ class VexCel(Source, ABC):
             for layer in self.layers
             if not layer
             .lower()
+            # exclude greyscale imagery
             .endswith('-g')
         }
         for cand in self.prefer_layers:

--- a/src/tile2net/raster/source.py
+++ b/src/tile2net/raster/source.py
@@ -52,11 +52,6 @@ class Coverage:
                 continue
             try:
                 coverage = source.coverage
-                if isinstance(
-                        coverage,
-                        shapely.geometry.base.BaseGeometry
-                ):
-                    coverage = GeoSeries([coverage], crs='epsg:4326')
                 axis = pd.Index([source.name] * len(coverage), name='source')
                 coverage = (
                     coverage
@@ -724,6 +719,7 @@ class VexCel(Source, ABC):
 
 
 class Maine(VexCel):
+    # https://www.maine.gov/geolib/data/index.html
     name = 'maine'
     api_key = "vfa_JkRqdw7HHOis.37zZe0OHVVqPlIY91FsT9arC9uGrDalMqwMW1AX4OgcfsiwtQoxDLed9OEIxKy3Ys2lMCam9C2swLrUwNqX2KrlegBRev8MRDpkqHkbSEn0fP1aEqvoDBdePjAOO9h91.4256792737"
     keyword = 'Maine'
@@ -749,6 +745,7 @@ class Maine(VexCel):
         "-70.11617000000001 43.68405, "
         "-70.64573401557249 43.09008331966716)))"
     )
+    coverage = GeoSeries(coverage, crs='epsg:4326')
 
 
 if __name__ == '__main__':

--- a/src/tile2net/raster/source.py
+++ b/src/tile2net/raster/source.py
@@ -618,9 +618,13 @@ class VexCel(Source, ABC):
     @class_attr
     @property
     def _session(self) -> requests.Session:
+        """
+        Create a requests session with
+        retries and a custom User-Agent.
+        """
         # ascii-only UA to avoid header encoding issues
         s = requests.Session()
-        s.headers.update({'User-Agent': 'tile2net/1.0 (xyz-wmts)'})
+        s.headers.update({'User-Agent': 'tile2net'})
         retry = Retry(
             total=5,
             backoff_factor=0.4,
@@ -638,6 +642,7 @@ class VexCel(Source, ABC):
             r: requests.Response,
             url: str,
     ) -> None:
+        """ Raise an HTTPError with details from the response."""
         ctype = r.headers.get('Content-Type', '')
         if ctype.startswith('text/'):
             body = r.text[:800]
@@ -673,10 +678,10 @@ class VexCel(Source, ABC):
             except ET.ParseError as e:
                 raise RuntimeError(f'Failed to parse WMTS capabilities: {e}') from e
 
-        ns = {
-            'wmts': 'http://www.opengis.net/wmts/1.0',
-            'ows': 'http://www.opengis.net/ows/1.1',
-        }
+        ns = dict(
+            wmts='http://www.opengis.net/wmts/1.0',
+            ows='http://www.opengis.net/ows/1.1',
+        )
         result = []
         for lyr in root.findall('.//wmts:Contents/wmts:Layer', ns):
             ident = lyr.find('ows:Identifier', ns)
@@ -764,4 +769,3 @@ if __name__ == '__main__':
     assert Source['Fremont, California'] == AlamedaCounty
     assert Source['Oakland, California'] == AlamedaCounty
     assert Source['San Francisco, California'] == SanFrancisco2024
-


### PR DESCRIPTION
In this PR we add the[ Maine imagery source](https://www.maine.gov/geolib/data/index.html). 

Key changes:

- Minor linting improvement and passing an array rather than an iterator for interpretability in `raster.py`
- Introduced the `VexCel` base class which is the tile service used by Maine
- Introduced the `Maine` class which is quite simple thanks to the VexCel base class:
```
class Maine(VexCel):
    # https://www.maine.gov/geolib/data/index.html
    name = 'maine'
    api_key = "vfa_JkRqdw7HHOis.37zZe0OHVVqPlIY91FsT9arC9uGrDalMqwMW1AX4OgcfsiwtQoxDLed9OEIxKy3Ys2lMCam9C2swLrUwNqX2KrlegBRev8MRDpkqHkbSEn0fP1aEqvoDBdePjAOO9h91.4256792737"
    keyword = 'Maine'
    coverage = wkt.loads(
        "MULTIPOLYGON (((-70.64573401557249 43.09008331966716, "
        ...
    )
    coverage = GeoSeries(coverage, crs='epsg:4326')
```
