### PR TITLE
Investigate geometry source selection for NYC

### DIFF
--- a/src/tile2net/raster/source.py
+++ b/src/tile2net/raster/source.py
@@ -130,7 +130,13 @@ class SourceMeta(ABCMeta):
                 raise SourceNotFound
         matches = matches.loc[loc]
 
-        # to resolve discrepancies, select where keyword is in the address
+        # NOTE:
+        # For geometry inputs, spatial filtering has already identified the
+        # candidate coverages. Reverse-geocoding the geometry may return an
+        # address (e.g. "New York") that does not contain the source keyword
+        # (e.g. "New York City"), causing the geometry-selected source to be
+        # discarded. Confirm whether keyword filtering is intended for geometry
+        # lookups.
         loc = []
         for name in matches.index:
             keyword: str | tuple[str]

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -34,6 +34,7 @@ def test_sources():
             continue
         # assert querying by the polygon returns the same source
         # assert Source[cls.coverage.unary_union] == cls
+        # NOTE: this is the failing test
         assert Source[cls.coverage.union_all()] == cls
         # assert querying by the keyword returns the same source
         if isinstance(cls.keyword, str):


### PR DESCRIPTION
## Summary

This PR investigates the failing `test_sources` test. I traced the failure to the source selection logic in `SourceMeta.__getitem__` and wanted to get feedback on the intended behavior before implementing a final fix.

## Investigation

The failing assertion is:

```python
assert Source[cls.coverage.union_all()] == cls
```

After stepping through `SourceMeta.__getitem__`, I found that:

- The spatial filtering step correctly identifies the matching candidate sources (`nyc`, `ny`, and `nj`).
- The geometry is then reverse geocoded.
- The reverse-geocoded address for the NYC coverage contains "New York" but not the configured NYC keywords ("New York City" / "City of New York").
- During keyword filtering, the nyc candidate is removed, leaving only the statewide ny source, which causes the test to fail.

The issue is during the keyword filtering stage rather than the spatial lookup itself.

Question:
I'm not sure whether keyword filtering is intended to apply to geometry inputs. Since spatial intersection has already narrowed the candidate sources, I'm wondering if geometry lookups should bypass this filtering or if there's another intended mechanism for resolving this case.